### PR TITLE
fix: retry GitHub GraphQL timeouts during Projects SSG

### DIFF
--- a/lib/githubQuery.ts
+++ b/lib/githubQuery.ts
@@ -1,0 +1,90 @@
+const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
+const RETRYABLE_ERROR_CODES = new Set([
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN"
+]);
+
+function readErrorCode(value: object): string | undefined {
+  const code = "code" in value ? value.code : undefined;
+  return typeof code === "string" ? code : undefined;
+}
+
+function readStatusCode(value: object): number | undefined {
+  const statusCode = "statusCode" in value ? value.statusCode : undefined;
+  if (typeof statusCode === "number") {
+    return statusCode;
+  }
+
+  const status = "status" in value ? value.status : undefined;
+  return typeof status === "number" ? status : undefined;
+}
+
+function isRetryableMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized === "terminated" ||
+    normalized.includes("other side closed") ||
+    normalized.includes("fetch failed") ||
+    normalized.includes("network") ||
+    normalized.includes("timeout") ||
+    normalized.includes("socket")
+  );
+}
+
+export function isRetryableGithubError(error: unknown): boolean {
+  const seen = new Set<object>();
+  let current: unknown = error;
+
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+
+    const status = readStatusCode(current);
+    if (status !== undefined && RETRYABLE_STATUS_CODES.has(status)) {
+      return true;
+    }
+
+    const code = readErrorCode(current);
+    if (code && RETRYABLE_ERROR_CODES.has(code)) {
+      return true;
+    }
+
+    if (current instanceof Error && isRetryableMessage(current.message)) {
+      return true;
+    }
+
+    const nextCause = "cause" in current ? current.cause : undefined;
+    const nextNetworkError =
+      "networkError" in current ? current.networkError : undefined;
+    current = nextCause ?? nextNetworkError;
+  }
+
+  return false;
+}
+
+export async function queryGithubWithRetry<T>(
+  query: () => Promise<T>,
+  attempts = 4
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await query();
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableGithubError(error) || attempt === attempts) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1500 * attempt));
+    }
+  }
+
+  throw lastError;
+}

--- a/lib/githubQuery.ts
+++ b/lib/githubQuery.ts
@@ -1,4 +1,6 @@
 const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
+const MAX_RETRY_AFTER_MS = 8000;
+const JITTER_MS = 250;
 const RETRYABLE_ERROR_CODES = new Set([
   "UND_ERR_SOCKET",
   "UND_ERR_CONNECT_TIMEOUT",
@@ -68,6 +70,65 @@ export function isRetryableGithubError(error: unknown): boolean {
   return false;
 }
 
+function readRetryAfterMs(error: unknown): number | undefined {
+  const seen = new Set<object>();
+  let current: unknown = error;
+
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+
+    if (readStatusCode(current) === 429) {
+      const response = "response" in current ? current.response : undefined;
+      const headers =
+        response && typeof response === "object" && "headers" in response
+          ? response.headers
+          : "headers" in current
+            ? current.headers
+            : undefined;
+      const retryAfter = readHeader(headers, "retry-after");
+      if (retryAfter) {
+        return parseRetryAfterMs(retryAfter);
+      }
+    }
+
+    const nextCause = "cause" in current ? current.cause : undefined;
+    const nextNetworkError =
+      "networkError" in current ? current.networkError : undefined;
+    current = nextCause ?? nextNetworkError;
+  }
+
+  return undefined;
+}
+
+function readHeader(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== "object") {
+    return undefined;
+  }
+
+  if ("get" in headers && typeof headers.get === "function") {
+    const value = headers.get(name);
+    return typeof value === "string" ? value : undefined;
+  }
+
+  const record = headers as Record<string, unknown>;
+  const direct = record[name] ?? record[name.toLowerCase()];
+  return typeof direct === "string" ? direct : undefined;
+}
+
+function parseRetryAfterMs(value: string): number | undefined {
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
+  }
+
+  const dateMs = Date.parse(value);
+  if (Number.isNaN(dateMs)) {
+    return undefined;
+  }
+
+  return Math.min(Math.max(dateMs - Date.now(), 0), MAX_RETRY_AFTER_MS);
+}
+
 export async function queryGithubWithRetry<T>(
   query: () => Promise<T>,
   attempts = 4
@@ -82,7 +143,10 @@ export async function queryGithubWithRetry<T>(
       if (!isRetryableGithubError(error) || attempt === attempts) {
         throw error;
       }
-      await new Promise((resolve) => setTimeout(resolve, 1500 * attempt));
+      const retryAfterMs = readRetryAfterMs(error);
+      const delay =
+        (retryAfterMs ?? 1500 * attempt) + Math.floor(Math.random() * JITTER_MS);
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
 

--- a/pages/Projects.tsx
+++ b/pages/Projects.tsx
@@ -11,7 +11,7 @@ import {
 import { ApolloClient, InMemoryCache, HttpLink, gql } from "@apollo/client";
 import { SetContextLink } from "@apollo/client/link/context";
 
-import type { PinnedRepository, GitHubApiResponse } from "../types/github";
+import type { PinnedRepository, GitHubUserProfile } from "../types/github";
 import ProjectCategorySwitcher from "../components/ProjectCategorySwitcher";
 import {
   PROJECT_CATEGORIES,
@@ -19,6 +19,7 @@ import {
   getProjectsForCategory,
   type ProjectCategoryId
 } from "../lib/projectCategories";
+import { queryGithubWithRetry } from "../lib/githubQuery";
 import { getProjectImageSrc } from "../lib/projectImage";
 
 import { AiOutlineStar, AiOutlineFork, AiFillEye, AiFillGithub } from "react-icons/ai";
@@ -316,52 +317,89 @@ const Projects: React.FC<ProjectsProps> = ({ pinnedItems, repositories }) => {
   );
 };
 
-function isRetryableGithubError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-
-  const directStatus =
-    "statusCode" in error && typeof error.statusCode === "number"
-      ? error.statusCode
-      : undefined;
-  const nestedError =
-    "networkError" in error &&
-    error.networkError &&
-    typeof error.networkError === "object"
-      ? error.networkError
-      : undefined;
-  const nestedStatus =
-    nestedError &&
-    "statusCode" in nestedError &&
-    typeof nestedError.statusCode === "number"
-      ? nestedError.statusCode
-      : undefined;
-  const status = directStatus ?? nestedStatus;
-
-  return status === 502 || status === 503 || status === 504;
-}
-
-async function queryGithubWithRetry<T>(
-  query: () => Promise<T>,
-  attempts = 3
-): Promise<T> {
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    try {
-      return await query();
-    } catch (error) {
-      lastError = error;
-      if (!isRetryableGithubError(error) || attempt === attempts) {
-        throw error;
+const REPOSITORY_CARD_FIELDS = gql`
+  fragment RepositoryCardFields on Repository {
+    id
+    name
+    forkCount
+    stargazerCount
+    openGraphImageUrl
+    isPrivate
+    defaultBranchRef {
+      name
+    }
+    assignableUsers(first: 3) {
+      edges {
+        node {
+          id
+          avatarUrl
+          name
+        }
       }
-      await new Promise((resolve) => setTimeout(resolve, 1500 * attempt));
+    }
+    description
+    url
+    repositoryTopics(first: 20) {
+      edges {
+        node {
+          id
+          topic {
+            name
+          }
+        }
+      }
+    }
+    watchers {
+      totalCount
+    }
+    homepageUrl
+  }
+`;
+
+const PINNED_PROJECTS_QUERY = gql`
+  query PinnedProjects {
+    user(login: "pountzas") {
+      id
+      pinnedItems(first: 6) {
+        edges {
+          node {
+            ... on Repository {
+              ...RepositoryCardFields
+              object(expression: "main") {
+                ... on Commit {
+                  id
+                  history {
+                    totalCount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
+  ${REPOSITORY_CARD_FIELDS}
+`;
 
-  throw lastError;
-}
+const REPOSITORY_LIST_QUERY = gql`
+  query RepositoryList {
+    user(login: "pountzas") {
+      repositories(
+        first: 100
+        ownerAffiliations: OWNER
+        orderBy: { field: UPDATED_AT, direction: DESC }
+      ) {
+        edges {
+          node {
+            ...RepositoryCardFields
+          }
+        }
+      }
+    }
+  }
+  ${REPOSITORY_CARD_FIELDS}
+`;
 
 export async function getStaticProps() {
   const httpLink = new HttpLink({
@@ -382,130 +420,31 @@ export async function getStaticProps() {
     cache: new InMemoryCache()
   });
 
-  const { data } = await queryGithubWithRetry(() =>
-    client.query<GitHubApiResponse>({
-      query: gql`
-      {
-        user(login: "pountzas") {
-          id
-          pinnedItems(first: 6) {
-            edges {
-              node {
-                ... on Repository {
-                  id
-                  name
-                  forkCount
-                  stargazerCount
-                  openGraphImageUrl
-                  isPrivate
-                  defaultBranchRef {
-                    name
-                  }
-                  assignableUsers(first: 3) {
-                    edges {
-                      node {
-                        id
-                        avatarUrl
-                        name
-                      }
-                    }
-                  }
-                  description
-                  url
-                  repositoryTopics(first: 20) {
-                    edges {
-                      node {
-                        id
-                        topic {
-                          name
-                        }
-                      }
-                    }
-                  }
-                  watchers {
-                    totalCount
-                  }
-                  homepageUrl
-                  object(expression: "main") {
-                    ... on Commit {
-                      id
-                      history {
-                        totalCount
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          repositories(
-            first: 100
-            ownerAffiliations: OWNER
-            orderBy: { field: UPDATED_AT, direction: DESC }
-          ) {
-            edges {
-              node {
-                id
-                name
-                forkCount
-                stargazerCount
-                openGraphImageUrl
-                isPrivate
-                defaultBranchRef {
-                  name
-                }
-                assignableUsers(first: 3) {
-                  edges {
-                    node {
-                      id
-                      avatarUrl
-                      name
-                    }
-                  }
-                }
-                description
-                url
-                repositoryTopics(first: 20) {
-                  edges {
-                    node {
-                      id
-                      topic {
-                        name
-                      }
-                    }
-                  }
-                }
-                watchers {
-                  totalCount
-                }
-                homepageUrl
-                object(expression: "main") {
-                  ... on Commit {
-                    id
-                    history {
-                      totalCount
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    `
+  const pinnedResult = await queryGithubWithRetry(() =>
+    client.query<{ user: Pick<GitHubUserProfile, "id" | "pinnedItems"> }>({
+      query: PINNED_PROJECTS_QUERY
+    })
+  );
+  const repositoryResult = await queryGithubWithRetry(() =>
+    client.query<{ user: Pick<GitHubUserProfile, "repositories"> }>({
+      query: REPOSITORY_LIST_QUERY
     })
   );
 
-  if (!data) {
+  const pinnedUser = pinnedResult.data?.user;
+  const repositoryUser = repositoryResult.data?.user;
+
+  if (!pinnedUser || !repositoryUser) {
     throw new Error("Failed to fetch GitHub data");
   }
 
-  const { user } = data;
   const pinned = excludeTemplateRepos(
-    user.pinnedItems.edges.map(({ node }: { node: PinnedRepository }) => node)
+    pinnedUser.pinnedItems.edges.map(({ node }: { node: PinnedRepository }) => node)
   );
   const repositories = excludeTemplateRepos(
-    user.repositories.edges.map(({ node }: { node: PinnedRepository }) => node)
+    repositoryUser.repositories.edges.map(
+      ({ node }: { node: PinnedRepository }) => node
+    )
   );
 
   return {

--- a/pages/Projects.tsx
+++ b/pages/Projects.tsx
@@ -316,6 +316,53 @@ const Projects: React.FC<ProjectsProps> = ({ pinnedItems, repositories }) => {
   );
 };
 
+function isRetryableGithubError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const directStatus =
+    "statusCode" in error && typeof error.statusCode === "number"
+      ? error.statusCode
+      : undefined;
+  const nestedError =
+    "networkError" in error &&
+    error.networkError &&
+    typeof error.networkError === "object"
+      ? error.networkError
+      : undefined;
+  const nestedStatus =
+    nestedError &&
+    "statusCode" in nestedError &&
+    typeof nestedError.statusCode === "number"
+      ? nestedError.statusCode
+      : undefined;
+  const status = directStatus ?? nestedStatus;
+
+  return status === 502 || status === 503 || status === 504;
+}
+
+async function queryGithubWithRetry<T>(
+  query: () => Promise<T>,
+  attempts = 3
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await query();
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableGithubError(error) || attempt === attempts) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1500 * attempt));
+    }
+  }
+
+  throw lastError;
+}
+
 export async function getStaticProps() {
   const httpLink = new HttpLink({
     uri: "https://api.github.com/graphql"
@@ -335,8 +382,9 @@ export async function getStaticProps() {
     cache: new InMemoryCache()
   });
 
-  const { data } = await client.query<GitHubApiResponse>({
-    query: gql`
+  const { data } = await queryGithubWithRetry(() =>
+    client.query<GitHubApiResponse>({
+      query: gql`
       {
         user(login: "pountzas") {
           id
@@ -445,7 +493,8 @@ export async function getStaticProps() {
         }
       }
     `
-  });
+    })
+  );
 
   if (!data) {
     throw new Error("Failed to fetch GitHub data");

--- a/pages/Projects.tsx
+++ b/pages/Projects.tsx
@@ -11,7 +11,11 @@ import {
 import { ApolloClient, InMemoryCache, HttpLink, gql } from "@apollo/client";
 import { SetContextLink } from "@apollo/client/link/context";
 
-import type { PinnedRepository, GitHubUserProfile } from "../types/github";
+import {
+  isGitHubRepository,
+  type GitHubUserProfile,
+  type PinnedRepository
+} from "../types/github";
 import ProjectCategorySwitcher from "../components/ProjectCategorySwitcher";
 import {
   PROJECT_CATEGORIES,
@@ -49,6 +53,8 @@ const ProjectCard = memo<ProjectCardProps>(({ item, index, size = "default" }) =
     () => item.repositoryTopics?.edges || [],
     [item.repositoryTopics]
   );
+  const commitHistory =
+    item.object?.history ?? item.defaultBranchRef?.target?.history;
 
   return (
     <motion.div
@@ -80,13 +86,13 @@ const ProjectCard = memo<ProjectCardProps>(({ item, index, size = "default" }) =
           blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAhEAACAQMDBQAAAAAAAAAAAAABAgMABAUGIWGRkqGx0f/EABUBAQEAAAAAAAAAAAAAAAAAAAMF/8QAGhEAAgIDAAAAAAAAAAAAAAAAAAECEgMRkf/aAAwDAQACEQMRAD8AltJagyeH0AthI5xdrLcNM91BF5pX2HaH9bcfaSXWGaRmknyJckliyjqTzSlT54b6bk+h0R+IRjWjBqO6O2mhP//Z"
         />
         <div className="absolute top-auto flex items-center justify-center pb-2 inset-1">
-          <Activity mode={item.object ? "visible" : "hidden"}>
+          <Activity mode={commitHistory ? "visible" : "hidden"}>
             <p
               className={`flex m-1 font-bold text-gray-800 bg-teal-500 border rounded-full shadow-lg cursor-pointer border-cyan-600 hover:text-blue-900 ${
                 isCompact ? "px-2 py-0.5 text-[10px]" : "px-3 py-1 text-xs md:text-md"
               }`}>
               <span className="pr-1">Commits: </span>
-              {item.object?.history?.totalCount}
+              {commitHistory?.totalCount}
             </p>
           </Activity>
 
@@ -363,13 +369,16 @@ const PINNED_PROJECTS_QUERY = gql`
       pinnedItems(first: 6) {
         edges {
           node {
+            __typename
             ... on Repository {
               ...RepositoryCardFields
-              object(expression: "main") {
-                ... on Commit {
-                  id
-                  history {
-                    totalCount
+              defaultBranchRef {
+                target {
+                  ... on Commit {
+                    id
+                    history {
+                      totalCount
+                    }
                   }
                 }
               }
@@ -420,16 +429,18 @@ export async function getStaticProps() {
     cache: new InMemoryCache()
   });
 
-  const pinnedResult = await queryGithubWithRetry(() =>
-    client.query<{ user: Pick<GitHubUserProfile, "id" | "pinnedItems"> }>({
-      query: PINNED_PROJECTS_QUERY
-    })
-  );
-  const repositoryResult = await queryGithubWithRetry(() =>
-    client.query<{ user: Pick<GitHubUserProfile, "repositories"> }>({
-      query: REPOSITORY_LIST_QUERY
-    })
-  );
+  const [pinnedResult, repositoryResult] = await Promise.all([
+    queryGithubWithRetry(() =>
+      client.query<{ user: Pick<GitHubUserProfile, "id" | "pinnedItems"> }>({
+        query: PINNED_PROJECTS_QUERY
+      })
+    ),
+    queryGithubWithRetry(() =>
+      client.query<{ user: Pick<GitHubUserProfile, "repositories"> }>({
+        query: REPOSITORY_LIST_QUERY
+      })
+    )
+  ]);
 
   const pinnedUser = pinnedResult.data?.user;
   const repositoryUser = repositoryResult.data?.user;
@@ -439,12 +450,10 @@ export async function getStaticProps() {
   }
 
   const pinned = excludeTemplateRepos(
-    pinnedUser.pinnedItems.edges.map(({ node }: { node: PinnedRepository }) => node)
+    pinnedUser.pinnedItems.edges.map((edge) => edge.node).filter(isGitHubRepository)
   );
   const repositories = excludeTemplateRepos(
-    repositoryUser.repositories.edges.map(
-      ({ node }: { node: PinnedRepository }) => node
-    )
+    repositoryUser.repositories.edges.map((edge) => edge.node)
   );
 
   return {

--- a/types/github.ts
+++ b/types/github.ts
@@ -40,9 +40,11 @@ export interface CommitObject {
 
 export interface DefaultBranchRef {
   name: string;
+  target?: CommitObject | null;
 }
 
 export interface GitHubRepository {
+  __typename?: string;
   id: string;
   name: string;
   description: string | null;
@@ -62,7 +64,7 @@ export interface GitHubRepository {
 }
 
 export interface PinnedItemEdge {
-  node: GitHubRepository;
+  node: GitHubRepository | { __typename?: string };
 }
 
 export interface PinnedItemsConnection {
@@ -89,3 +91,20 @@ export interface GitHubApiResponse {
 
 // Type for the processed pinned items used in components
 export type PinnedRepository = GitHubRepository;
+
+export function isGitHubRepository(node: unknown): node is GitHubRepository {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if ("__typename" in node && typeof node.__typename === "string") {
+    return node.__typename === "Repository";
+  }
+
+  return (
+    "name" in node &&
+    "url" in node &&
+    "isPrivate" in node &&
+    "openGraphImageUrl" in node
+  );
+}


### PR DESCRIPTION
## Summary
- Retry GitHub GraphQL requests in `getStaticProps` when GitHub returns 502/503/504 so `/Projects` static generation does not fail the Vercel production build on a transient timeout.

## Test plan
- [ ] Confirm the Vercel production build for this PR completes (`next build` does not fail on `/Projects`).
- [ ] Open `/Projects` and confirm pinned and category lists still populate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when loading GitHub project data by retrying temporary network and server errors.
  * Non-retryable errors now fail immediately with clearer handling.
  * Pinned projects and repository listings are loaded independently, reducing the impact of partial failures.
  * Improved validation and filtering of GitHub data before displaying projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->